### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run build
+      - name: Prepare site
+        run: |
+          mkdir public
+          cp index.html public/index.html
+          cp -r dist public/dist
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ npm run build
 ```
 
 Open `index.html` in a browser to play.
+
+## GitHub Pages
+
+This repository includes a workflow that automatically builds the TypeScript code and publishes the game to the `gh-pages` branch. Once GitHub Pages is enabled for that branch, the game will be available online. After pushing to `main`, visit the repository settings on GitHub and enable GitHub Pages using the `gh-pages` branch as the source.


### PR DESCRIPTION
## Summary
- build TypeScript and deploy to GitHub Pages using a GitHub Actions workflow
- explain how to enable Pages in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684da2c78c8c83319b364faa1cc56995