### PR TITLE
Add mobile tilt controls and restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ npm run build
 
 Open `index.html` in a browser to play.
 
+## Controls
+
+- **Desktop:** Use the left and right arrow keys to move and space bar to fire.
+- **Mobile:** Tilt your device left or right to steer the ship and tap the screen to shoot. After a crash, tap the Restart button to play again.
+
 ## GitHub Pages
 
 This repository includes a workflow that automatically builds the TypeScript code and publishes the game to the `gh-pages` branch. Once GitHub Pages is enabled for that branch, the game will be available online. After pushing to `main`, visit the repository settings on GitHub and enable GitHub Pages using the `gh-pages` branch as the source.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 </head>
 <body>
   <canvas id="game"></canvas>
+  <button id="restart" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); font-size:24px; display:none;">Restart</button>
   <script src="dist/main.js"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 const canvas = document.getElementById('game') as HTMLCanvasElement;
+const restartButton = document.getElementById('restart') as HTMLButtonElement;
 const ctx = canvas.getContext('2d')!;
 
 const canvasWidth = canvas.width = window.innerWidth;
@@ -55,6 +56,18 @@ interface Missile {
 }
 const missiles: Missile[] = [];
 let gameOver = false;
+
+function resetGame() {
+  obstacles.length = 0;
+  missiles.length = 0;
+  stars.splice(0, stars.length);
+  for (let i = 0; i < 100; i++) {
+    stars.push(createStar());
+  }
+  spaceship.x = canvasWidth / 2 - spaceship.width / 2;
+  gameOver = false;
+  restartButton.style.display = 'none';
+}
 
 function createStar() {
   return {
@@ -135,6 +148,7 @@ function checkCollisions() {
       explosionSound.currentTime = 0;
       explosionSound.play();
       gameOver = true;
+      restartButton.style.display = 'block';
     }
   });
 
@@ -206,5 +220,25 @@ window.addEventListener('touchstart', e => {
   const touch = e.touches[0];
   if (touch.clientX < canvasWidth / 2) spaceship.moveLeft();
   else spaceship.moveRight();
+});
+
+window.addEventListener('click', () => {
+  if (gameOver) return;
+  fireMissile();
+});
+
+window.addEventListener('deviceorientation', e => {
+  if (gameOver) return;
+  if (e.gamma == null) return;
+  const threshold = 10;
+  if (e.gamma > threshold) {
+    spaceship.moveRight();
+  } else if (e.gamma < -threshold) {
+    spaceship.moveLeft();
+  }
+});
+
+restartButton.addEventListener('click', () => {
+  resetGame();
 });
 


### PR DESCRIPTION
## Summary
- add on-screen restart button
- implement resetGame logic in game code
- support firing on tap
- use device tilt to steer
- document mobile controls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dbdc436c88331b8bf1c565fb03920