### PR TITLE
Add score, lives and pause features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Open `index.html` in a browser to play.
 
 ## Controls
 
-- **Desktop:** Use the left and right arrow keys to move and space bar to fire.
-- **Mobile:** Tilt your device left or right to steer the ship and tap the screen to shoot. After a crash, tap the Restart button to play again.
+- **Desktop:** Use the left and right arrow keys to move and space bar to fire. Press **Enter** to pause or resume.
+- **Mobile:** Tilt your device left or right to steer the ship and tap the screen to shoot. Double tap anywhere to pause or resume.
+- Destroy enemies to earn points. You start with three lives and gain an extra life every ten points. When all lives are lost, hit the Restart button to play again.
 
 ## GitHub Pages
 


### PR DESCRIPTION
## Summary
- add scoring system with extra lives
- track lives and add game over when they run out
- draw score and life counter in the corner
- allow pausing via `Enter` or double tap
- document the new controls

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dc132394c8331aca93e962a0e1e2c