### PR TITLE
Fix mobile double click pausing game

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -274,10 +274,6 @@ window.addEventListener('click', () => {
   fireMissile();
 });
 
-window.addEventListener('dblclick', () => {
-  if (gameOver) return;
-  paused = !paused;
-});
 
 window.addEventListener('deviceorientation', e => {
   if (gameOver || paused) return;


### PR DESCRIPTION
## Summary
- remove the `dblclick` pause handler so double taps don't pause gameplay

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dca22ab0883319415582876bea478