### PR TITLE
Add boss enemies with score bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Open `index.html` in a browser to play.
 - **Desktop:** Use the left and right arrow keys to move and space bar to fire. Press **Enter** to pause or resume.
 - **Mobile:** Tilt your device left or right to steer the ship and tap the screen to shoot. Slide your finger across the screen to pause or resume.
 - Destroy enemies to earn points. You start with three lives and gain an extra life every ten points. When all lives are lost, hit the Restart button to play again.
+- Every so often a boss ship appears. Taking it down awards a 10 point bonus.
 
 ## GitHub Pages
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,9 @@ friendImage.src = 'resources/friend.png';
 const enemyImage = new Image();
 enemyImage.src = 'resources/enemy.png';
 
+const bossImage = new Image();
+bossImage.src = 'resources/boss.png';
+
 // Load sound effects
 const explosionSound = new Audio('resources/explosion-80108.mp3');
 const laserSound = new Audio('resources/laser-zap-90575.mp3');
@@ -42,6 +45,7 @@ interface Obstacle {
   width: number;
   height: number;
   speed: number;
+  isBoss: boolean;
 }
 
 const spaceship = new Spaceship();
@@ -62,6 +66,11 @@ let lives = 3;
 let nextLifeScore = 10;
 let slideHandled = false; // track slide gesture for pausing on mobile
 
+function randomBossInterval() {
+  return Math.floor(Math.random() * 11) + 20;
+}
+let spawnsUntilBoss = randomBossInterval();
+
 function resetGame() {
   obstacles.length = 0;
   missiles.length = 0;
@@ -75,6 +84,7 @@ function resetGame() {
   score = 0;
   lives = 3;
   nextLifeScore = 10;
+  spawnsUntilBoss = randomBossInterval();
   restartButton.style.display = 'none';
 }
 
@@ -96,7 +106,12 @@ function spawnObstacle() {
   const height = 40;
   const x = Math.random() * (canvasWidth - width);
   const speed = 4 + Math.random() * 2;
-  obstacles.push({ x, y: -height, width, height, speed });
+  spawnsUntilBoss--;
+  const isBoss = spawnsUntilBoss <= 0;
+  if (isBoss) {
+    spawnsUntilBoss = randomBossInterval();
+  }
+  obstacles.push({ x, y: -height, width, height, speed, isBoss });
 }
 
 function fireMissile() {
@@ -183,7 +198,7 @@ function checkCollisions() {
         hitSound.play();
         obstacles.splice(oi, 1);
         missiles.splice(mi, 1);
-        score++;
+        score += 1 + (o.isBoss ? 10 : 0);
         if (score >= nextLifeScore) {
           lives++;
           nextLifeScore += 10;
@@ -211,7 +226,7 @@ function draw() {
   });
 
   obstacles.forEach(o => {
-    ctx.drawImage(enemyImage, o.x, o.y, o.width, o.height);
+    ctx.drawImage(o.isBoss ? bossImage : enemyImage, o.x, o.y, o.width, o.height);
   });
 
   ctx.fillStyle = 'white';


### PR DESCRIPTION
## Summary
- introduce `boss.png` image for special boss ships
- spawn boss ships every 20-30 enemies using random interval logic
- award a 10 point bonus when destroying a boss
- mention boss ships in the game README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dcba0ee908331889872917889ef76