### PR TITLE
Fix Airtable field names

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,8 +93,8 @@ async function sendScoreToAirtable(finalScore: number) {
     records: [
       {
         fields: {
-          score: finalScore,
-          'Date Of Play': new Date().toISOString(),
+          Score: finalScore,
+          'Date of Play': new Date().toISOString(),
         },
       },
     ],


### PR DESCRIPTION
## Summary
- update field names when sending score to Airtable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850731882148331a984dfd4df6759fd