### PR TITLE
Add username prompt and send to Airtable

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,13 @@
 <body>
   <canvas id="game"></canvas>
   <button id="restart" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); font-size:24px; display:none;">Restart</button>
+  <div id="name-modal" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); display:none; background:white; padding:20px; border:1px solid #ccc;">
+    <form id="name-form">
+      <label for="username-input">Enter your name:</label>
+      <input id="username-input" type="text" required />
+      <button type="submit">Start</button>
+    </form>
+  </div>
   <script src="dist/main.js"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,15 @@
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const restartButton = document.getElementById('restart') as HTMLButtonElement;
+const nameModal = document.getElementById('name-modal') as HTMLDivElement;
+const nameForm = document.getElementById('name-form') as HTMLFormElement;
+const nameInput = document.getElementById('username-input') as HTMLInputElement;
 const ctx = canvas.getContext('2d')!;
 
 const canvasWidth = canvas.width = window.innerWidth;
 const canvasHeight = canvas.height = window.innerHeight;
+
+const PLAYER_NAME_KEY = 'playerName';
+let playerName: string | null = localStorage.getItem(PLAYER_NAME_KEY);
 
 // Airtable configuration
 const AIRTABLE_API_KEY =
@@ -91,7 +97,7 @@ function formatDate(date: Date): string {
   return `${month}/${day}/${year}`;
 }
 
-async function sendScoreToAirtable(finalScore: number) {
+async function sendScoreToAirtable(finalScore: number, name: string | null) {
   const url =
     `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${encodeURIComponent(
       AIRTABLE_TABLE_NAME
@@ -101,6 +107,7 @@ async function sendScoreToAirtable(finalScore: number) {
       {
         fields: {
           Score: finalScore,
+          Name: name || 'Anonymous',
           'Date of Play': formatDate(new Date()),
         },
       },
@@ -269,7 +276,7 @@ function checkCollisions() {
       lives--;
       if (lives <= 0) {
         gameOver = true;
-        sendScoreToAirtable(score);
+        sendScoreToAirtable(score, playerName);
         restartButton.style.display = 'block';
       }
       break;
@@ -393,5 +400,21 @@ window.addEventListener('deviceorientation', e => {
 
 restartButton.addEventListener('click', () => {
   resetGame();
+});
+
+if (!playerName) {
+  paused = true;
+  nameModal.style.display = 'block';
+}
+
+nameForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const name = nameInput.value.trim();
+  if (name) {
+    playerName = name;
+    localStorage.setItem(PLAYER_NAME_KEY, name);
+    nameModal.style.display = 'none';
+    paused = false;
+  }
 });
 


### PR DESCRIPTION
## Summary
- add modal form to collect player's name
- store name in localStorage and pause game until provided
- include saved name when uploading score to Airtable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68507786ecbc83318282fee9ffd76116