### PR TITLE
Add scoreboard on game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
       <button type="submit">Start</button>
     </form>
   </div>
+  <div id="scoreboard" style="position:absolute; top:10%; left:50%; transform:translateX(-50%); background:white; padding:20px; display:none;">
+    <table id="score-table"></table>
+  </div>
   <script src="dist/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add scoreboard container
- show top 10 Airtable scores after game over

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685079e545148331b2927dfc975bd6b1