### PR TITLE
Enhance scoreboard styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,17 @@
   <style>
     html, body { margin: 0; padding: 0; overflow: hidden; }
     canvas { display: block; background: black; }
+    #scoreboard {
+      background: rgba(255, 255, 255, 0.8);
+    }
+    #score-table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    #score-table th, #score-table td {
+      padding: 4px 8px;
+      border-bottom: 1px solid grey;
+    }
   </style>
 </head>
 <body>
@@ -19,9 +30,9 @@
       <button type="submit">Start</button>
     </form>
   </div>
-  <div id="scoreboard" style="position:absolute; top:10%; left:50%; transform:translateX(-50%); background:white; padding:20px; display:none;">
-    <table id="score-table"></table>
-  </div>
+    <div id="scoreboard" style="position:absolute; top:10%; left:50%; transform:translateX(-50%); padding:20px; display:none;">
+      <table id="score-table"></table>
+    </div>
   <script src="dist/main.js"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,6 +155,10 @@ function displayScores(records: any[]) {
     const fields = r.fields;
     const row = document.createElement('tr');
     row.innerHTML = `<td>${fields.Name}</td><td>${fields.Score}</td><td>${fields['Date of Play']}</td>`;
+    if (playerName && fields.Name === playerName) {
+      row.style.backgroundColor = '#fffa8b';
+      row.style.fontWeight = 'bold';
+    }
     scoreTable.appendChild(row);
   });
   scoreboard.style.display = 'block';


### PR DESCRIPTION
## Summary
- style scoreboard with opacity and table borders
- highlight current player's score row in the table

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68507c3b0b548331a0d457acc04e961a