### PR TITLE
Implement local high score and new game restart

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
 </head>
 <body>
   <canvas id="game"></canvas>
-  <button id="restart" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); font-size:24px; display:none;">Restart</button>
   <div id="name-modal" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); display:none; background:white; padding:20px; border:1px solid #ccc;">
     <form id="name-form">
       <label for="username-input">Enter your name:</label>


### PR DESCRIPTION
## Summary
- remove Restart button from `index.html`
- track player high score in `localStorage`
- show `New Game` when the game ends and allow clicking/tapping to restart
- update top info line to display the saved high score

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852fe4460188331a3655ede0559d8f5