### PR TITLE
Enhance stage 2 visuals and ship speed

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -3,30 +3,47 @@ export interface Star {
   y: number;
   size: number;
   speed: number;
+  color: string;
 }
 
-export function createStar(canvasWidth: number, canvasHeight: number): Star {
-  return {
+export function createStar(
+  canvasWidth: number,
+  canvasHeight: number,
+  stage: number
+): Star {
+  const base = {
     x: Math.random() * canvasWidth,
     y: Math.random() * canvasHeight,
     size: Math.random() * 2 + 1,
     speed: Math.random() * 1 + 0.5,
   };
+  const colors = ['white', 'blue', 'red', 'yellow'];
+  const color = stage > 1 ? colors[Math.floor(Math.random() * colors.length)] : 'white';
+  return { ...base, color };
 }
 
-export function updateStars(stars: Star[], canvasWidth: number, canvasHeight: number) {
+export function updateStars(
+  stars: Star[],
+  canvasWidth: number,
+  canvasHeight: number,
+  stage: number
+) {
   stars.forEach(s => {
     s.y += s.speed;
     if (s.y > canvasHeight) {
       s.y = 0;
       s.x = Math.random() * canvasWidth;
+      if (stage > 1) {
+        const colors = ['white', 'blue', 'red', 'yellow'];
+        s.color = colors[Math.floor(Math.random() * colors.length)];
+      }
     }
   });
 }
 
 export function drawStars(ctx: CanvasRenderingContext2D, stars: Star[]) {
-  ctx.fillStyle = 'white';
   stars.forEach(s => {
+    ctx.fillStyle = s.color;
     ctx.fillRect(s.x, s.y, s.size, s.size);
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,9 +41,10 @@ const laserSound = new Audio('resources/laser-zap-90575.mp3');
 const hitSound = new Audio('resources/explosion-322491.mp3');
 
 const spaceship = new Spaceship(canvasWidth, canvasHeight);
+let stage = 1;
 const stars: Star[] = [];
 for (let i = 0; i < 100; i++) {
-  stars.push(createStar(canvasWidth, canvasHeight));
+  stars.push(createStar(canvasWidth, canvasHeight, stage));
 }
 
 let gameOver = false;
@@ -93,9 +94,10 @@ function resetGame() {
   shipPieces.length = 0;
   enemyExplosions.length = 0;
   freezeEnvironment = false;
+  stage = 1;
   stars.splice(0, stars.length);
   for (let i = 0; i < 100; i++) {
-    stars.push(createStar(canvasWidth, canvasHeight));
+    stars.push(createStar(canvasWidth, canvasHeight, stage));
   }
   spaceship.x = canvasWidth / 2 - spaceship.width / 2;
   gameOver = false;
@@ -114,9 +116,10 @@ function startNextLevel() {
   missiles.length = 0;
   shipPieces.length = 0;
   enemyExplosions.length = 0;
+  stage++;
   stars.splice(0, stars.length);
   for (let i = 0; i < 100; i++) {
-    stars.push(createStar(canvasWidth, canvasHeight));
+    stars.push(createStar(canvasWidth, canvasHeight, stage));
   }
   spaceship.x = canvasWidth / 2 - spaceship.width / 2;
   spawnsUntilBoss.value = Math.floor(Math.random() * 11) + 20;
@@ -323,7 +326,7 @@ function update() {
   updateMissiles();
   updatePortal();
   updateExplosions();
-  updateStars(stars, canvasWidth, canvasHeight);
+  updateStars(stars, canvasWidth, canvasHeight, stage);
   checkCollisions();
   checkPortalCollision();
 }
@@ -349,6 +352,13 @@ function draw() {
   drawExplosions(ctx);
 
   drawTopInfo(ctx, playerName, score, lives, topScore, canvasWidth);
+
+  if (levelTransition) {
+    ctx.fillStyle = 'white';
+    ctx.font = '64px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(`Stage ${stage + 1}`, canvasWidth / 2, canvasHeight / 2);
+  }
 
   if (paused && !gameOver) {
     ctx.font = '48px sans-serif';

--- a/src/spaceship.ts
+++ b/src/spaceship.ts
@@ -3,7 +3,8 @@ export class Spaceship {
   height = 60;
   x: number;
   y: number;
-  speed = 9;
+  // Increase speed by roughly 30% for snappier keyboard control
+  speed = 12;
 
   constructor(private canvasWidth: number, private canvasHeight: number) {
     this.x = canvasWidth / 2 - this.width / 2;


### PR DESCRIPTION
## Summary
- bump spaceship speed by ~30%
- keep track of game stage and spawn stars using stage awareness
- color stars randomly for stage 2
- show "Stage 2" text when entering the portal

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855a7e3e1e8833186272f026cc89d7e