### PR TITLE
Add stage 3 enemy with new scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Open `index.html` in a browser to play.
 - **Mobile:** Tilt your device left or right to steer the ship and tap the screen to shoot.
 - Destroy enemies to earn points. You start with three lives and gain an extra life every ten points. When all lives are lost, hit the Restart button to play again.
 - Every so often a boss ship appears. Taking it down awards a 10 point bonus.
+- Beginning with stage 3, a new enemy type appears. Roughly 30% of enemies will use the `enemy3.png` sprite and are worth 2 points when destroyed.
 
 ## GitHub Pages
 

--- a/src/enemy.ts
+++ b/src/enemy.ts
@@ -7,6 +7,8 @@ export interface Obstacle {
   height: number;
   speed: number;
   isBoss: boolean;
+  /** Whether this obstacle uses the stage 3 sprite */
+  isEnemy3?: boolean;
 }
 
 export interface Missile {
@@ -20,7 +22,11 @@ export interface Missile {
 export const obstacles: Obstacle[] = [];
 export const missiles: Missile[] = [];
 
-export function spawnObstacle(canvasWidth: number, spawnsUntilBoss: { value: number }) {
+export function spawnObstacle(
+  canvasWidth: number,
+  spawnsUntilBoss: { value: number },
+  stage: number
+) {
   const width = 40;
   const height = 40;
   const x = Math.random() * (canvasWidth - width);
@@ -30,7 +36,12 @@ export function spawnObstacle(canvasWidth: number, spawnsUntilBoss: { value: num
   if (isBoss) {
     spawnsUntilBoss.value = Math.floor(Math.random() * 11) + 20;
   }
-  obstacles.push({ x, y: -height, width, height, speed, isBoss });
+  let isEnemy3 = false;
+  if (!isBoss && stage >= 3) {
+    // 30% chance to use the new enemy sprite
+    isEnemy3 = Math.random() < 0.3;
+  }
+  obstacles.push({ x, y: -height, width, height, speed, isBoss, isEnemy3 });
 }
 
 export function fireMissile(ship: Spaceship, laserSound: HTMLAudioElement) {
@@ -73,8 +84,18 @@ export function drawMissiles(ctx: CanvasRenderingContext2D) {
   });
 }
 
-export function drawObstacles(ctx: CanvasRenderingContext2D, enemyImage: HTMLImageElement, bossImage: HTMLImageElement) {
+export function drawObstacles(
+  ctx: CanvasRenderingContext2D,
+  enemyImage: HTMLImageElement,
+  bossImage: HTMLImageElement,
+  enemy3Image: HTMLImageElement
+) {
   obstacles.forEach(o => {
-    ctx.drawImage(o.isBoss ? bossImage : enemyImage, o.x, o.y, o.width, o.height);
+    const img = o.isBoss
+      ? bossImage
+      : o.isEnemy3
+      ? enemy3Image
+      : enemyImage;
+    ctx.drawImage(img, o.x, o.y, o.width, o.height);
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,8 @@ const friendImage = new Image();
 friendImage.src = 'resources/friend.png';
 const enemyImage = new Image();
 enemyImage.src = 'resources/enemy.png';
+const enemy3Image = new Image();
+enemy3Image.src = 'resources/enemy3.png';
 const bossImage = new Image();
 bossImage.src = 'resources/boss.png';
 const portalImage = new Image();
@@ -281,7 +283,10 @@ function checkCollisions() {
         spawnExplosion(o.x + o.width / 2, o.y + o.height / 2);
         obstacles.splice(oi, 1);
         missiles.splice(mi, 1);
-        score += 1 + (o.isBoss ? 10 : 0);
+        let points = 1;
+        if (o.isBoss) points += 10;
+        if (o.isEnemy3) points += 1; // enemy3 gives total 2 points
+        score += points;
         if (score >= nextLifeScore) {
           lives++;
           nextLifeScore += 10;
@@ -315,7 +320,7 @@ function update() {
 
   if (gameOver || paused) return;
   if (Math.random() < 0.02) {
-    spawnObstacle(canvasWidth, spawnsUntilBoss);
+    spawnObstacle(canvasWidth, spawnsUntilBoss, stage);
   }
 
   if (score >= nextPortalScore && !portal) {
@@ -347,7 +352,7 @@ function draw() {
   }
 
   drawMissiles(ctx);
-  drawObstacles(ctx, enemyImage, bossImage);
+  drawObstacles(ctx, enemyImage, bossImage, enemy3Image);
   drawPortal(ctx);
   drawExplosions(ctx);
 


### PR DESCRIPTION
## Summary
- create new enemy type that appears from stage 3
- grant 2 points for destroying the new enemy
- load `enemy3.png` sprite and draw appropriately
- document the new enemy in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855abe8fc8c83318b56a664a8fe9fc5