### PR TITLE
Add flying asteroid enemy

### DIFF
--- a/src/asteroid.ts
+++ b/src/asteroid.ts
@@ -1,0 +1,44 @@
+export interface Asteroid {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  speed: number;
+  direction: 1 | -1; // 1 = left->right, -1 = right->left
+}
+
+export const asteroids: Asteroid[] = [];
+
+export function spawnAsteroid(canvasWidth: number, canvasHeight: number) {
+  const width = 60;
+  const height = 40;
+  const direction: 1 | -1 = Math.random() < 0.5 ? 1 : -1;
+  const speed = 3 + Math.random() * 2;
+  const x = direction === 1 ? -width : canvasWidth + width;
+  const y = Math.random() * (canvasHeight * 0.4); // keep mostly in the upper half
+  asteroids.push({ x, y, width, height, speed, direction });
+}
+
+export function updateAsteroids(canvasWidth: number) {
+  for (let i = asteroids.length - 1; i >= 0; i--) {
+    const a = asteroids[i];
+    a.x += a.speed * a.direction;
+    if ((a.direction === 1 && a.x > canvasWidth + a.width) ||
+        (a.direction === -1 && a.x < -a.width)) {
+      asteroids.splice(i, 1);
+    }
+  }
+}
+
+export function drawAsteroids(ctx: CanvasRenderingContext2D, img: HTMLImageElement) {
+  asteroids.forEach(a => {
+    ctx.save();
+    const cx = a.x + a.width / 2;
+    const cy = a.y + a.height / 2;
+    ctx.translate(cx, cy);
+    const angle = a.direction === 1 ? -Math.PI / 6 : Math.PI / 6;
+    ctx.rotate(angle);
+    ctx.drawImage(img, -a.width / 2, -a.height / 2, a.width, a.height);
+    ctx.restore();
+  });
+}


### PR DESCRIPTION
## Summary
- introduce asteroid module for stage 2+
- draw rotated asteroid image when moving left or right
- spawn and update asteroids in the main loop
- check collisions with spaceship and missiles

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68566a4d5f48833198c77283999657e4