### PR TITLE
Change asteroid movement to vertical approach

### DIFF
--- a/src/asteroid.ts
+++ b/src/asteroid.ts
@@ -3,28 +3,30 @@ export interface Asteroid {
   y: number;
   width: number;
   height: number;
-  speed: number;
-  direction: 1 | -1; // 1 = left->right, -1 = right->left
+  /** Horizontal drift speed */
+  speedX: number;
+  /** Downward movement speed */
+  speedY: number;
 }
 
 export const asteroids: Asteroid[] = [];
 
-export function spawnAsteroid(canvasWidth: number, canvasHeight: number) {
+export function spawnAsteroid(canvasWidth: number) {
   const width = 60;
   const height = 40;
-  const direction: 1 | -1 = Math.random() < 0.5 ? 1 : -1;
-  const speed = 3 + Math.random() * 2;
-  const x = direction === 1 ? -width : canvasWidth + width;
-  const y = Math.random() * (canvasHeight * 0.4); // keep mostly in the upper half
-  asteroids.push({ x, y, width, height, speed, direction });
+  const x = Math.random() * (canvasWidth - width);
+  const y = -height;
+  const speedY = 3 + Math.random() * 2;
+  const speedX = (Math.random() - 0.5) * 2; // slight horizontal drift
+  asteroids.push({ x, y, width, height, speedX, speedY });
 }
 
-export function updateAsteroids(canvasWidth: number) {
+export function updateAsteroids(canvasWidth: number, canvasHeight: number) {
   for (let i = asteroids.length - 1; i >= 0; i--) {
     const a = asteroids[i];
-    a.x += a.speed * a.direction;
-    if ((a.direction === 1 && a.x > canvasWidth + a.width) ||
-        (a.direction === -1 && a.x < -a.width)) {
+    a.x += a.speedX;
+    a.y += a.speedY;
+    if (a.x > canvasWidth + a.width || a.x < -a.width || a.y > canvasHeight + a.height) {
       asteroids.splice(i, 1);
     }
   }
@@ -36,7 +38,7 @@ export function drawAsteroids(ctx: CanvasRenderingContext2D, img: HTMLImageEleme
     const cx = a.x + a.width / 2;
     const cy = a.y + a.height / 2;
     ctx.translate(cx, cy);
-    const angle = a.direction === 1 ? -Math.PI / 6 : Math.PI / 6;
+    const angle = Math.atan2(a.speedX, a.speedY);
     ctx.rotate(angle);
     ctx.drawImage(img, -a.width / 2, -a.height / 2, a.width, a.height);
     ctx.restore();

--- a/src/main.ts
+++ b/src/main.ts
@@ -390,7 +390,7 @@ function update() {
   }
 
   if (stage >= 2 && Math.random() < 0.005) {
-    spawnAsteroid(canvasWidth, canvasHeight);
+    spawnAsteroid(canvasWidth);
   }
 
   if (score >= nextPortalScore && !portal) {
@@ -398,7 +398,7 @@ function update() {
   }
 
   updateObstacles(canvasHeight);
-  updateAsteroids(canvasWidth);
+  updateAsteroids(canvasWidth, canvasHeight);
   updateMissiles();
   updatePortal();
   updateExplosions();


### PR DESCRIPTION
## Summary
- modify asteroid interface to support vertical descent
- adjust spawning to start from the top with small horizontal drift
- update asteroid update logic and rotation
- update main loop to use new spawn and update calls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68566f450b5c8331a53c5d37561eb159