### PR TITLE
Implement VR mode scaling

### DIFF
--- a/src/asteroid.ts
+++ b/src/asteroid.ts
@@ -1,3 +1,5 @@
+import { SCALE } from './config.js';
+
 export interface Asteroid {
   x: number;
   y: number;
@@ -12,8 +14,8 @@ export interface Asteroid {
 export const asteroids: Asteroid[] = [];
 
 export function spawnAsteroid(canvasWidth: number) {
-  const width = 60;
-  const height = 40;
+  const width = 60 * SCALE;
+  const height = 40 * SCALE;
   const x = Math.random() * (canvasWidth - width);
   const y = -height;
   // Asteroids move twice as fast as regular enemies and

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,5 @@
+import { SCALE } from './config.js';
+
 export interface Star {
   x: number;
   y: number;
@@ -14,7 +16,7 @@ export function createStar(
   const base = {
     x: Math.random() * canvasWidth,
     y: Math.random() * canvasHeight,
-    size: Math.random() * 2 + 1,
+    size: (Math.random() * 2 + 1) * SCALE,
     speed: Math.random() * 1 + 0.5,
   };
   const colors = ['white', 'blue', 'red', 'yellow'];

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+export const isMobile = /Mobi|Android/i.test(navigator.userAgent);
+export const vrMode = isMobile && window.innerWidth > window.innerHeight;
+// Scale game objects relative to the reduced canvas width in VR mode
+export const SCALE = vrMode ? 0.5 : 1;

--- a/src/enemy.ts
+++ b/src/enemy.ts
@@ -1,4 +1,5 @@
 import { Spaceship } from './spaceship.js';
+import { SCALE } from './config.js';
 
 export interface Obstacle {
   x: number;
@@ -27,8 +28,8 @@ export function spawnObstacle(
   spawnsUntilBoss: { value: number },
   stage: number
 ) {
-  const width = 40;
-  const height = 40;
+  const width = 40 * SCALE;
+  const height = 40 * SCALE;
   const x = Math.random() * (canvasWidth - width);
   const speed = 4 + Math.random() * 2;
   spawnsUntilBoss.value--;
@@ -45,8 +46,8 @@ export function spawnObstacle(
 }
 
 export function fireMissile(ship: Spaceship, laserSound: HTMLAudioElement) {
-  const width = 5;
-  const height = 10;
+  const width = 5 * SCALE;
+  const height = 10 * SCALE;
   const x = ship.x + ship.width / 2 - width / 2;
   const y = ship.y - height;
   const speed = 10;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,15 +18,13 @@ import {
 } from './asteroid.js';
 import { scoreboard, sendScoreToAirtable, fetchTopScores, displayScores } from './scoreboard.js';
 import { drawTopInfo } from './topInfo.js';
+import { vrMode, SCALE } from './config.js';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const nameModal = document.getElementById('name-modal') as HTMLDivElement;
 const nameForm = document.getElementById('name-form') as HTMLFormElement;
 const nameInput = document.getElementById('username-input') as HTMLInputElement;
 
-// Detect VR mode when running on a mobile device in landscape orientation
-const isMobile = /Mobi|Android/i.test(navigator.userAgent);
-const vrMode = isMobile && window.innerWidth > window.innerHeight;
 
 // Display context always refers to the on-screen canvas
 const displayCtx = canvas.getContext('2d')!;
@@ -245,8 +243,8 @@ function drawExplosions(ctx: CanvasRenderingContext2D) {
 }
 
 function spawnPortal() {
-  const width = 80;
-  const height = 80;
+  const width = 80 * SCALE;
+  const height = 80 * SCALE;
   const x = Math.random() * (canvasWidth - width);
   const speed = 3;
   portal = { x, y: -height, width, height, speed };

--- a/src/spaceship.ts
+++ b/src/spaceship.ts
@@ -1,10 +1,12 @@
+import { vrMode, SCALE } from './config.js';
+
 export class Spaceship {
-  width = 40;
-  height = 60;
+  width = 40 * SCALE;
+  height = 60 * SCALE;
   x: number;
   y: number;
-  // Increase speed by roughly 30% for snappier keyboard control
-  speed = 12;
+  // Base speed adjusted when VR mode is active
+  speed = 12 * (vrMode ? 0.7 : 1);
 
   constructor(private canvasWidth: number, private canvasHeight: number) {
     this.x = canvasWidth / 2 - this.width / 2;


### PR DESCRIPTION
## Summary
- add a config file that exposes `vrMode` and a global `SCALE`
- reduce all object sizes using `SCALE` in VR mode
- slow down spaceship speed by 30% when VR mode is active
- update portal spawn size accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685829e419e48331b9863b8898b98ece