### PR TITLE
Add introduction prefix story

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,17 @@
       border-bottom: 1px solid grey;
       color: white;
     }
+    #prefix-container {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: white;
+      font-family: sans-serif;
+      text-align: center;
+      display: none;
+      z-index: 10;
+    }
   </style>
 </head>
 <body>
@@ -33,6 +44,7 @@
       <button type="submit">Start</button>
     </form>
   </div>
+  <div id="prefix-container"></div>
     <div id="scoreboard" style="position:absolute; top:10%; left:50%; transform:translateX(-50%); padding:20px; display:none;">
       <table id="score-table"></table>
     </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import {
 } from './scoreboard.js';
 import { drawTopInfo } from './topInfo.js';
 import { vrMode, SCALE } from './config.js';
+import { showPrefixStory } from './prefix.js';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const nameModal = document.getElementById('name-modal') as HTMLDivElement;
@@ -641,6 +642,11 @@ window.addEventListener('deviceorientation', e => {
 if (!playerName) {
   paused = true;
   nameModal.style.display = 'block';
+} else {
+  paused = true;
+  showPrefixStory(playerName, () => {
+    paused = false;
+  });
 }
 
 nameForm.addEventListener('submit', e => {
@@ -651,6 +657,9 @@ nameForm.addEventListener('submit', e => {
     localStorage.setItem(PLAYER_NAME_KEY, name);
     topScore = parseInt(localStorage.getItem(HIGH_SCORE_KEY) || '0');
     nameModal.style.display = 'none';
-    paused = false;
+    paused = true;
+    showPrefixStory(playerName, () => {
+      paused = false;
+    });
   }
 });

--- a/src/prefix.ts
+++ b/src/prefix.ts
@@ -1,0 +1,47 @@
+export interface PrefixLine {
+  id: string;
+  text: string;
+}
+
+export const prefixStory: PrefixLine[] = [
+  { id: 'greeting', text: 'Hello {{playerName}}, this is Commander Omer.' },
+  {
+    id: 'alert',
+    text: 'The world has been attacked by {{enemyName}}, spreading chaos across the galaxy.'
+  },
+  { id: 'mission', text: 'You are the last spaceship with enough power to save the world.' },
+  { id: 'charge', text: 'We are counting on you—go out there and destroy them all!' }
+];
+
+const DEFAULT_ENEMY_NAME = 'the enemy forces';
+
+export function showPrefixStory(
+  playerName: string,
+  onComplete: () => void,
+  enemyName: string = DEFAULT_ENEMY_NAME
+) {
+  const container = document.getElementById('prefix-container') as HTMLDivElement;
+  if (!container) {
+    onComplete();
+    return;
+  }
+
+  let index = 0;
+  container.style.display = 'block';
+
+  const next = () => {
+    if (index >= prefixStory.length) {
+      container.style.display = 'none';
+      onComplete();
+      return;
+    }
+    const line = prefixStory[index].text
+      .replace('{{playerName}}', playerName)
+      .replace('{{enemyName}}', enemyName);
+    container.textContent = line;
+    index++;
+    setTimeout(next, 3000);
+  };
+
+  next();
+}


### PR DESCRIPTION
## Summary
- add prefix container markup and styles
- introduce `prefix.ts` with a scripted intro that uses the player's name
- trigger the prefix sequence after getting the name

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f9e304eec8331a6959c91ed2e7b93