### PR TITLE
Improve intro sequence and pause display

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      color: white;
-      font-family: sans-serif;
+      color: #0f0;
+      font-family: monospace;
       text-align: center;
       display: none;
       z-index: 10;

--- a/src/main.ts
+++ b/src/main.ts
@@ -516,7 +516,7 @@ function draw() {
   if (paused && !gameOver) {
     ctx.font = '48px sans-serif';
     ctx.textAlign = 'center';
-    ctx.fillText('Paused', canvasWidth / 2, canvasHeight / 2);
+    ctx.fillText('Paused', canvasWidth / 2, canvasHeight * 0.2);
   }
 
   if (gameOver) {

--- a/src/prefix.ts
+++ b/src/prefix.ts
@@ -15,6 +15,8 @@ export const prefixStory: PrefixLine[] = [
 
 const DEFAULT_ENEMY_NAME = 'the enemy forces';
 
+import { isMobile } from './config.js';
+
 export function showPrefixStory(
   playerName: string,
   onComplete: () => void,
@@ -27,18 +29,35 @@ export function showPrefixStory(
   }
 
   let index = 0;
+  container.innerHTML = '';
   container.style.display = 'block';
 
   const next = () => {
     if (index >= prefixStory.length) {
-      container.style.display = 'none';
-      onComplete();
+      if (!isMobile) {
+        const message = document.createElement('div');
+        message.textContent = 'Click enter to begin';
+        container.appendChild(message);
+        const startHandler = (e: KeyboardEvent) => {
+          if (e.key === 'Enter') {
+            window.removeEventListener('keydown', startHandler);
+            container.style.display = 'none';
+            onComplete();
+          }
+        };
+        window.addEventListener('keydown', startHandler);
+      } else {
+        container.style.display = 'none';
+        onComplete();
+      }
       return;
     }
-    const line = prefixStory[index].text
+    const lineText = prefixStory[index].text
       .replace('{{playerName}}', playerName)
       .replace('{{enemyName}}', enemyName);
-    container.textContent = line;
+    const lineEl = document.createElement('div');
+    lineEl.textContent = lineText;
+    container.appendChild(lineEl);
     index++;
     setTimeout(next, 3000);
   };


### PR DESCRIPTION
## Summary
- style intro text as green terminal text
- allow the prefix/manifest to accumulate lines and show a "Click enter to begin" prompt for desktop
- position pause message near the top of the screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fa07850c08331a5a77f2d96852e3d