### PR TITLE
Fix prefix display overlapping with pause

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import {
 } from './scoreboard.js';
 import { drawTopInfo } from './topInfo.js';
 import { vrMode, SCALE } from './config.js';
-import { showPrefixStory } from './prefix.js';
+import { showPrefixStory, prefixActive } from './prefix.js';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const nameModal = document.getElementById('name-modal') as HTMLDivElement;
@@ -513,7 +513,7 @@ function draw() {
     ctx.fillText(`Stage ${stage + 1}`, canvasWidth / 2, canvasHeight / 2);
   }
 
-  if (paused && !gameOver) {
+  if (paused && !gameOver && !prefixActive) {
     ctx.font = '48px sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText('Paused', canvasWidth / 2, canvasHeight * 0.2);

--- a/src/prefix.ts
+++ b/src/prefix.ts
@@ -17,6 +17,8 @@ const DEFAULT_ENEMY_NAME = 'the enemy forces';
 
 import { isMobile } from './config.js';
 
+export let prefixActive = false;
+
 export function showPrefixStory(
   playerName: string,
   onComplete: () => void,
@@ -27,6 +29,8 @@ export function showPrefixStory(
     onComplete();
     return;
   }
+
+  prefixActive = true;
 
   let index = 0;
   container.innerHTML = '';
@@ -42,12 +46,14 @@ export function showPrefixStory(
           if (e.key === 'Enter') {
             window.removeEventListener('keydown', startHandler);
             container.style.display = 'none';
+            prefixActive = false;
             onComplete();
           }
         };
         window.addEventListener('keydown', startHandler);
       } else {
         container.style.display = 'none';
+        prefixActive = false;
         onComplete();
       }
       return;


### PR DESCRIPTION
## Summary
- prevent pause text from displaying when the prefix story is visible
- track prefix active state

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fa2099a1c8331a0f611c1ac65ae3c