### PR TITLE
Add commander image during prefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,16 @@
       display: none;
       z-index: 10;
     }
+    #command-image {
+      position: absolute;
+      right: 10%;
+      bottom: 10%;
+      width: 200px;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.5s ease;
+      z-index: 9;
+    }
   </style>
 </head>
 <body>
@@ -45,6 +55,7 @@
     </form>
   </div>
   <div id="prefix-container"></div>
+  <img id="command-image" src="resources/commander.png" alt="Commander" />
     <div id="scoreboard" style="position:absolute; top:10%; left:50%; transform:translateX(-50%); padding:20px; display:none;">
       <table id="score-table"></table>
     </div>

--- a/src/prefix.ts
+++ b/src/prefix.ts
@@ -25,6 +25,7 @@ export function showPrefixStory(
   enemyName: string = DEFAULT_ENEMY_NAME
 ) {
   const container = document.getElementById('prefix-container') as HTMLDivElement;
+  const commandImg = document.getElementById('command-image') as HTMLImageElement | null;
   if (!container) {
     onComplete();
     return;
@@ -35,6 +36,7 @@ export function showPrefixStory(
   let index = 0;
   container.innerHTML = '';
   container.style.display = 'block';
+  if (commandImg) commandImg.style.opacity = '1';
 
   const next = () => {
     if (index >= prefixStory.length) {
@@ -47,6 +49,7 @@ export function showPrefixStory(
             window.removeEventListener('keydown', startHandler);
             container.style.display = 'none';
             prefixActive = false;
+            if (commandImg) commandImg.style.opacity = '0';
             onComplete();
           }
         };
@@ -54,6 +57,7 @@ export function showPrefixStory(
       } else {
         container.style.display = 'none';
         prefixActive = false;
+        if (commandImg) commandImg.style.opacity = '0';
         onComplete();
       }
       return;
@@ -68,5 +72,5 @@ export function showPrefixStory(
     setTimeout(next, 3000);
   };
 
-  next();
+  setTimeout(next, 500);
 }


### PR DESCRIPTION
## Summary
- display commander image during the intro prefix
- fade commander image in/out using opacity

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68601da019b8833183347e73069f8656