### PR TITLE
Implement click sound during prefix typing

### DIFF
--- a/src/prefix.ts
+++ b/src/prefix.ts
@@ -17,20 +17,15 @@ const DEFAULT_ENEMY_NAME = 'the enemy forces';
 
 import { isMobile } from './config.js';
 
-const AudioCtx = (window as any).AudioContext || (window as any).webkitAudioContext;
-const clickCtx: AudioContext | null = AudioCtx ? new AudioCtx() : null;
+const clickAudioSrc = 'resources/soundOfClick.mp3';
 
 function playClick() {
-  if (!clickCtx) return;
-  const osc = clickCtx.createOscillator();
-  const gain = clickCtx.createGain();
-  osc.type = 'square';
-  osc.frequency.value = 800;
-  osc.connect(gain);
-  gain.connect(clickCtx.destination);
-  gain.gain.setValueAtTime(0.1, clickCtx.currentTime);
-  osc.start();
-  osc.stop(clickCtx.currentTime + 0.05);
+  const audio = new Audio(clickAudioSrc);
+  audio.play();
+  setTimeout(() => {
+    audio.pause();
+    audio.currentTime = 0;
+  }, 100);
 }
 
 export let prefixActive = false;


### PR DESCRIPTION
## Summary
- use `soundOfClick.mp3` each time a character appears in the intro text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686025169ce08331977a2769523013aa