### PR TITLE
Add lobby screen before prefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,56 @@
       transition: opacity 3s ease;
       z-index: 9;
     }
+    #lobby {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: none;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+      color: #0f0;
+      font-family: monospace;
+      font-size: 18px;
+      background-image: url('resources/stroid2.jpeg');
+      background-size: cover;
+      animation: lobby-scroll 20s linear infinite;
+      z-index: 11;
+    }
+    @keyframes lobby-scroll {
+      from { background-position: 0 0; }
+      to { background-position: 0 100%; }
+    }
+    #lobby-play {
+      margin-top: auto;
+      margin-bottom: auto;
+      animation: blink 1s step-start infinite;
+      cursor: pointer;
+    }
+    @keyframes blink {
+      0%, 50%, 100% { opacity: 1; }
+      25%, 75% { opacity: 0; }
+    }
+    #lobby-bottom {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      padding: 0 20px 10px;
+    }
   </style>
 </head>
 <body>
   <canvas id="game"></canvas>
+  <div id="lobby">
+    <div id="lobby-top">Your name: <span id="lobby-name"></span></div>
+    <div id="lobby-play">PLAY</div>
+    <div id="lobby-bottom">
+      <span>Skin</span>
+      <span>Show</span>
+    </div>
+  </div>
   <div id="name-modal" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); display:none; background:white; padding:20px; border:1px solid #ccc;">
     <form id="name-form">
       <label for="username-input">Enter your name:</label>

--- a/src/lobby.ts
+++ b/src/lobby.ts
@@ -1,0 +1,20 @@
+export function showLobby(playerName: string, onPlay: () => void) {
+  const lobby = document.getElementById('lobby') as HTMLDivElement | null;
+  const nameSpan = document.getElementById('lobby-name') as HTMLSpanElement | null;
+  const playEl = document.getElementById('lobby-play') as HTMLDivElement | null;
+  if (!lobby || !nameSpan || !playEl) {
+    onPlay();
+    return;
+  }
+
+  nameSpan.textContent = playerName;
+  lobby.style.display = 'flex';
+
+  const handler = () => {
+    lobby.style.display = 'none';
+    playEl.removeEventListener('click', handler);
+    onPlay();
+  };
+
+  playEl.addEventListener('click', handler);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
 import { drawTopInfo } from './topInfo.js';
 import { vrMode, SCALE } from './config.js';
 import { showPrefixStory, prefixActive } from './prefix.js';
+import { showLobby } from './lobby.js';
 
 const canvas = document.getElementById('game') as HTMLCanvasElement;
 const nameModal = document.getElementById('name-modal') as HTMLDivElement;
@@ -644,8 +645,10 @@ if (!playerName) {
   nameModal.style.display = 'block';
 } else {
   paused = true;
-  showPrefixStory(playerName, () => {
-    paused = false;
+  showLobby(playerName!, () => {
+    showPrefixStory(playerName!, () => {
+      paused = false;
+    });
   });
 }
 
@@ -658,8 +661,10 @@ nameForm.addEventListener('submit', e => {
     topScore = parseInt(localStorage.getItem(HIGH_SCORE_KEY) || '0');
     nameModal.style.display = 'none';
     paused = true;
-    showPrefixStory(playerName, () => {
-      paused = false;
+    showLobby(playerName!, () => {
+      showPrefixStory(playerName!, () => {
+        paused = false;
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary
- create a lobby phase shown before the prefix story
- style lobby with green monospace text and scrolling background
- implement `showLobby` helper and trigger it from `main.ts`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686027f3a2fc833186535cfb441f7e8f