### PR TITLE
Add stage-specific background images

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,6 +98,10 @@ const portalImage = new Image();
 portalImage.src = 'resources/Portal2.png';
 const asteroidImage = new Image();
 asteroidImage.src = 'resources/stroid2.jpeg';
+const background2Image = new Image();
+background2Image.src = 'resources/background2.png';
+const backgroundImage = new Image();
+backgroundImage.src = 'resources/background.png';
 
 const explosionSound = new Audio('resources/explosion-80108.mp3');
 const laserSound = new Audio('resources/laser-zap-90575.mp3');
@@ -484,8 +488,14 @@ function update() {
 }
 
 function draw() {
-  ctx.fillStyle = 'black';
-  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+  if (stage >= 4) {
+    ctx.drawImage(backgroundImage, 0, 0, canvasWidth, canvasHeight);
+  } else if (stage >= 3) {
+    ctx.drawImage(background2Image, 0, 0, canvasWidth, canvasHeight);
+  } else {
+    ctx.fillStyle = 'black';
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+  }
 
   drawStars(ctx, stars);
 


### PR DESCRIPTION
## Summary
- update game draw loop to show backgrounds for later stages
- load `background2.png` and `background.png` as image resources

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864208204508331963256d373999ed7