### PR TITLE
Adjust background opacity

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -488,6 +488,8 @@ function update() {
 }
 
 function draw() {
+  ctx.save();
+  ctx.globalAlpha = 0.3;
   if (stage >= 4) {
     ctx.drawImage(backgroundImage, 0, 0, canvasWidth, canvasHeight);
   } else if (stage >= 3) {
@@ -496,6 +498,7 @@ function draw() {
     ctx.fillStyle = 'black';
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);
   }
+  ctx.restore();
 
   drawStars(ctx, stars);
 


### PR DESCRIPTION
## Summary
- fade the game's background images by drawing them at 30% opacity

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864231edf9883318b7f50a10387da19