### PR TITLE
Add new boss5 enemy ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Open `index.html` in a browser to play.
 - Every so often a boss ship appears. Taking it down awards a 10 point bonus.
 - Beginning with stage 3, a new enemy type appears. Roughly 30% of enemies will use the `enemy3.png` sprite and are worth 2 points when destroyed.
 - Starting in stage 1 another enemy using `bos4.png` may appear. It occasionally shoots back and is worth 15 points when destroyed.
+- From stage 3 another tough ship may show up using `boss5.png`. It appears far
+  less frequently (about 20% as often as normal enemies), requires two hits to
+  destroy and awards 5 points.
 
 ## GitHub Pages
 

--- a/src/enemy.ts
+++ b/src/enemy.ts
@@ -12,6 +12,10 @@ export interface Obstacle {
   isEnemy3?: boolean;
   /** New enemy type that appears from stage 1 */
   isBos4?: boolean;
+  /** Enemy that requires two hits starting in stage 3 */
+  isBoss5?: boolean;
+  /** Remaining health points */
+  health: number;
 }
 
 export interface Missile {
@@ -49,6 +53,15 @@ export function spawnObstacle(
   if (!isBoss && Math.random() < 0.1) {
     isBos4 = true;
   }
+  let isBoss5 = false;
+  let health = 1;
+  if (!isBoss && stage >= 3 && Math.random() < 0.2) {
+    isBoss5 = true;
+    health = 2;
+    // When this enemy appears, do not treat it as other special types
+    isEnemy3 = false;
+    isBos4 = false;
+  }
   obstacles.push({
     x,
     y: -height,
@@ -58,6 +71,8 @@ export function spawnObstacle(
     isBoss,
     isEnemy3,
     isBos4,
+    isBoss5,
+    health,
   });
 }
 
@@ -131,11 +146,14 @@ export function drawObstacles(
   enemyImage: HTMLImageElement,
   bossImage: HTMLImageElement,
   enemy3Image: HTMLImageElement,
-  bos4Image: HTMLImageElement
+  bos4Image: HTMLImageElement,
+  boss5Image: HTMLImageElement
 ) {
   obstacles.forEach(o => {
     const img = o.isBoss
       ? bossImage
+      : o.isBoss5
+      ? boss5Image
       : o.isBos4
       ? bos4Image
       : o.isEnemy3

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,8 @@ const bossImage = new Image();
 bossImage.src = 'resources/boss.png';
 const bos4Image = new Image();
 bos4Image.src = 'resources/bos4.png';
+const boss5Image = new Image();
+boss5Image.src = 'resources/boss5.png';
 const portalImage = new Image();
 portalImage.src = 'resources/Portal2.png';
 const asteroidImage = new Image();
@@ -410,16 +412,20 @@ function checkCollisions() {
         hitSound.currentTime = 0;
         hitSound.play();
         spawnExplosion(o.x + o.width / 2, o.y + o.height / 2);
-        obstacles.splice(oi, 1);
         missiles.splice(mi, 1);
-        let points = 1;
-        if (o.isBoss) points += 10;
-        if (o.isEnemy3) points += 1; // enemy3 gives total 2 points
-        if (o.isBos4) points += 14; // bos4 worth 15 total
-        score += points;
-        if (score >= nextLifeScore) {
-          lives++;
-          nextLifeScore += 10;
+        o.health--;
+        if (o.health <= 0) {
+          obstacles.splice(oi, 1);
+          let points = 1;
+          if (o.isBoss) points += 10;
+          if (o.isEnemy3) points += 1; // enemy3 gives total 2 points
+          if (o.isBos4) points += 14; // bos4 worth 15 total
+          if (o.isBoss5) points += 4; // boss5 worth 5 total
+          score += points;
+          if (score >= nextLifeScore) {
+            lives++;
+            nextLifeScore += 10;
+          }
         }
         break;
       }
@@ -513,7 +519,7 @@ function draw() {
 
   drawMissiles(ctx);
   drawEnemyShots(ctx);
-  drawObstacles(ctx, enemyImage, bossImage, enemy3Image, bos4Image);
+  drawObstacles(ctx, enemyImage, bossImage, enemy3Image, bos4Image, boss5Image);
   drawAsteroids(ctx, asteroidImage);
   drawPortal(ctx);
   drawExplosions(ctx);


### PR DESCRIPTION
## Summary
- add bullet in README about new `boss5.png` enemy
- spawn `boss5` enemies from stage 3 in `enemy.ts`
- handle drawing and scoring for boss5
- load boss5 image and pass through to drawObstacles
- make boss5 require two hits and give 5 points

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b42156be083318a11dc401b70dd08