### PR TITLE
Add looping gameplay soundtrack and pause-aware audio control

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,8 @@ const bcBackgrounds: HTMLImageElement[] = [];
 const explosionSound = new Audio('resources/explosion-80108.mp3');
 const laserSound = new Audio('resources/laser-zap-90575.mp3');
 const hitSound = new Audio('resources/explosion-322491.mp3');
+const soundtrack = new Audio('resources/Voidfall_Anomaly.mp3');
+soundtrack.loop = true;
 
 const spaceship = new Spaceship(canvasWidth, canvasHeight);
 // Keyboard controls move the ship twice as far per key press
@@ -176,6 +178,22 @@ let freezeEnvironment = false;
 
 const spawnsUntilBoss = { value: Math.floor(Math.random() * 11) + 20 };
 
+function syncSoundtrackPlayback() {
+  const shouldPlay = !paused && !gameOver && !prefixActive;
+  if (shouldPlay) {
+    if (soundtrack.paused) {
+      soundtrack.play().catch(() => {
+        // Ignore autoplay blocks until the user interacts with the page.
+      });
+    }
+    return;
+  }
+
+  if (!soundtrack.paused) {
+    soundtrack.pause();
+  }
+}
+
 function resetGame() {
   obstacles.length = 0;
   missiles.length = 0;
@@ -207,6 +225,8 @@ function resetGame() {
   scoreboard.style.display = 'none';
   if (scoreboardRight) scoreboardRight.style.display = 'none';
   canvas.style.cursor = 'default';
+  soundtrack.currentTime = 0;
+  syncSoundtrackPlayback();
 }
 
 function startNextLevel() {
@@ -624,6 +644,7 @@ function draw() {
 }
 
 function loop() {
+  syncSoundtrackPlayback();
   update();
   draw();
   requestAnimationFrame(loop);
@@ -635,6 +656,7 @@ window.addEventListener('keydown', e => {
   if (gameOver) return;
   if (e.key === 'Enter') {
     paused = !paused;
+    syncSoundtrackPlayback();
     return;
   }
   if (paused) return;
@@ -702,11 +724,14 @@ window.addEventListener('deviceorientation', e => {
 if (!playerName) {
   paused = true;
   nameModal.style.display = 'block';
+  syncSoundtrackPlayback();
 } else {
   paused = true;
+  syncSoundtrackPlayback();
   showLobby(playerName!, () => {
     showPrefixStory(playerName!, () => {
       paused = false;
+      syncSoundtrackPlayback();
     });
   });
 }
@@ -720,9 +745,11 @@ nameForm.addEventListener('submit', e => {
     topScore = parseInt(localStorage.getItem(HIGH_SCORE_KEY) || '0');
     nameModal.style.display = 'none';
     paused = true;
+    syncSoundtrackPlayback();
     showLobby(playerName!, () => {
       showPrefixStory(playerName!, () => {
         paused = false;
+        syncSoundtrackPlayback();
       });
     });
   }


### PR DESCRIPTION
### Motivation
- Provide background music during gameplay using the newly added `resources/Voidfall_Anomaly.mp3` so the game has a continuous soundtrack. 
- Ensure audio respects game state (pause, intro/prefix, game over) so music does not play while the game is paused or before the player starts.

### Description
- Added a new `Audio` instance for the soundtrack in `src/main.ts` with `soundtrack.loop = true` to enable continuous playback. 
- Implemented `syncSoundtrackPlayback()` to start or pause the soundtrack depending on `paused`, `gameOver`, and `prefixActive` state. 
- Wired `syncSoundtrackPlayback()` into the main frame `loop()`, the Enter key pause toggle, the name/prefix/lobby flow, and `resetGame()` to reset `soundtrack.currentTime` and keep playback in sync with gameplay. 
- Kept autoplay errors silent by catching the promise from `soundtrack.play()` so the UI remains stable when browsers block autoplay until user interaction.

### Testing
- Ran `npm run build` to compile TypeScript and verify there are no type or build errors, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71e9606848331900575321d60185d)